### PR TITLE
Add native library version information

### DIFF
--- a/src/main/java/org/hid4java/HidServices.java
+++ b/src/main/java/org/hid4java/HidServices.java
@@ -205,4 +205,13 @@ public class HidServices {
       return value;
     }
   }
+
+  /**
+   * Returns the full version of the underlying hidapi library
+   *
+   * @return The version in major.minor.patch format
+   */
+  public static String getNativeVersion() {
+    return HidApi.getVersion();
+  }
 }

--- a/src/main/java/org/hid4java/jna/HidApi.java
+++ b/src/main/java/org/hid4java/jna/HidApi.java
@@ -488,4 +488,18 @@ public class HidApi {
     }
   }
 
+  /**
+   * Returns the full version of the underlying hidapi library
+   *
+   * @return The version in major.minor.patch format
+   *
+   * @see org.hid4java.HidServices#getNativeVersion
+   */
+  public static String getVersion() {
+    if(hidApiLibrary == null) {
+      init();
+    }
+    return hidApiLibrary.hid_version_str();
+  }
+
 }

--- a/src/main/java/org/hid4java/jna/HidApiLibrary.java
+++ b/src/main/java/org/hid4java/jna/HidApiLibrary.java
@@ -269,4 +269,11 @@ public interface HidApiLibrary extends Library {
    * @return The pointer if successful or null
    */
   Pointer hid_open_path(String path);
+
+  /**
+   * Get version of hidapi library
+   *
+   * @return Version in major.minor.patch format
+   */
+  String hid_version_str();
 }


### PR DESCRIPTION
Adds a new API call to fetch the underlying native hidapi version.

```java
HidServices.getNativeVersion();
// 0.11.0
```

Note:

* This does NOT include the [`-dev` suffix which is present in the native hidapi version information](https://github.com/libusb/hidapi/blob/c84cf1dec3d2653c9ffe1473422413d7358444ad/VERSION#L1) because hidapi does [not expose this information](https://github.com/libusb/hidapi/blob/ec0727c34409936240f8ed7fecf2030241d4a9c2/hidapi/hidapi.h#L61).
* To avoid a `NullPointerException`, it will call `HidApi.init()` if needed.  If this is undesired, please let me know.

 