### PR TITLE
added option to open devices on darwin in non-exclusive mode

### DIFF
--- a/src/main/java/org/hid4java/jna/DarwinHidApiLibrary.java
+++ b/src/main/java/org/hid4java/jna/DarwinHidApiLibrary.java
@@ -1,0 +1,24 @@
+package org.hid4java.jna;
+
+import com.sun.jna.Native;
+import com.sun.jna.WString;
+
+public interface DarwinHidApiLibrary extends HidrawHidApiLibrary {
+
+  DarwinHidApiLibrary INSTANCE = Native.load("hidapi", DarwinHidApiLibrary.class);
+
+  /**
+   * Changes the behavior of all further calls to {@link #hid_open(short, short, WString)} or {@link #hid_open_path(String)}.
+   * <p>
+   * All devices opened by HIDAPI with {@link #hid_open(short, short, WString)} or {@link #hid_open_path(String)}
+   * are opened in exclusive mode per default.
+   * <p>
+   * Calling this function before {@link #hid_init()} or after {@link #hid_exit()} has no effect.
+   *
+   * @since hidapi 0.12.0
+   * @param openExclusive When set to 0 - all further devices will be opened in non-exclusive mode.
+   *                      Otherwise - all further devices will be opened in exclusive mode.
+   */
+  void hid_darwin_set_open_exclusive(int openExclusive);
+
+}

--- a/src/main/java/org/hid4java/jna/HidApi.java
+++ b/src/main/java/org/hid4java/jna/HidApi.java
@@ -62,6 +62,14 @@ public class HidApi {
   public static boolean useLibUsbVariant = false;
 
   /**
+   * When false - all devices will be opened in exclusive mode. (Default)
+   * When true - all devices will be opened in non-exclusive mode.
+   * <p>
+   * See {@link DarwinHidApiLibrary#hid_darwin_set_open_exclusive(int)} for more information.
+   */
+  public static boolean darwinOpenDevicesNonExclusive = false;
+
+  /**
    * Enables HID traffic logging to stdout to assist debugging. This will show all bytes (including the extra report ID)
    * that were sent or received via HIDAPI buffers. It does not log direct string calls (e.g. getEnumeratedString()).
    *
@@ -110,11 +118,17 @@ public class HidApi {
 
     if (useLibUsbVariant && Platform.isLinux()) {
       hidApiLibrary = LibusbHidApiLibrary.INSTANCE;
+    } else if (Platform.isMac()) {
+      hidApiLibrary = DarwinHidApiLibrary.INSTANCE;
     } else {
       hidApiLibrary = HidrawHidApiLibrary.INSTANCE;
     }
 
     hidApiLibrary.hid_init();
+
+    if (hidApiLibrary instanceof DarwinHidApiLibrary) {
+      ((DarwinHidApiLibrary) hidApiLibrary).hid_darwin_set_open_exclusive(darwinOpenDevicesNonExclusive ? 0 : 1);
+    }
   }
 
   /**


### PR DESCRIPTION
Closes gary-rowe/hid4java#131

Requires libhidapi `0.12.0`.

Tested locally with `libhidapi.0.12.0.dylib` and jna `5.8.0` on M1 Max Macbook Pro.