### PR TITLE
Add support for Linux armel

### DIFF
--- a/build-hidapi.sh
+++ b/build-hidapi.sh
@@ -281,7 +281,6 @@ echo -e "${green}---------------------------------------------------------------
 # 32-bit ARM soft float (linux-armel)
 if [[ "$1" == "all" ]] || [[ "$1" == "linux" ]] || [[ "$1" == "linux-armel" ]]
   then
-    echo -e "${yellow}Skipping linux-arm (use RPi direct instead)${plain}"
     echo -e "${green}Building ARM soft float${plain}"  && git-clean
     make clean &> /dev/null
 

--- a/build-hidapi.sh
+++ b/build-hidapi.sh
@@ -31,6 +31,7 @@
 # linux-aarch64 - Linux ARMv8 64-bit
 # linux-amd64 - Linux AMD 64-bit
 # linux-arm - Linux ARMv6 hard float 32-bit (RPi)
+# linux-armel - Linux ARMv5 soft float 32-bit
 # linux-x86-64 - Linux x86 64-bit (same as AMD64)
 # linux-x86 - Linux x86 32-bit
 # win32-x86 - Windows 32-bit
@@ -93,6 +94,12 @@ chmod +x ./dockcross-linux-x86
 mv ./dockcross-linux-x86 ~/bin
 
 # ARM cross compilers
+
+# 32-bit ARMv5TE EABI "armel"
+echo -e "${green}Configuring ARMv5TE EABI 32-bit${plain}"
+docker run --rm dockcross/linux-armv5 > ./dockcross-linux-armv5
+chmod +x ./dockcross-linux-armv5
+mv ./dockcross-linux-armv5 ~/bin
 
 # 32-bit ARMv6 EABI
 echo -e "${green}Configuring ARMv6 EABI 32-bit${plain}"
@@ -268,6 +275,39 @@ if [[ "$1" == "all" ]] || [[ "$1" == "linux" ]] || [[ "$1" == "linux-arm" ]]
 #    fi
   else
     echo -e "${yellow}Skipping linux-arm${plain}"
+fi
+echo -e "${green}------------------------------------------------------------------------${plain}"
+
+# 32-bit ARM soft float (linux-armel)
+if [[ "$1" == "all" ]] || [[ "$1" == "linux" ]] || [[ "$1" == "linux-armel" ]]
+  then
+    echo -e "${yellow}Skipping linux-arm (use RPi direct instead)${plain}"
+    echo -e "${green}Building ARM soft float${plain}"  && git-clean
+    make clean &> /dev/null
+
+    # Disabling building hidtest
+    sed -i'' -e 's/SUBDIRS \+= hidtest//g' Makefile.am
+
+    arch="armel"
+    deps="echo \"Obtaining $arch dependencies...\""
+    deps="$deps && sudo dpkg --add-architecture $arch"
+    deps="$deps && sudo apt-get update"
+    deps="$deps && sudo apt-get --yes install libudev-dev:$arch libusb-1.0-0-dev:$arch"
+    deps="$deps ;  echo 'WARNING: Ignoring any errors from previous command'"
+    deps="$deps && cp /usr/include/libudev.h ./libudev.h"
+    deps="$deps && export PKG_CONFIG_PATH=/usr/lib/arm-linux-gnueabi/pkgconfig/"
+    if ! dockcross-linux-armv5 bash -c "$deps && sudo ./bootstrap && sudo ./configure --host=aarch64-unknown-linux-gnueabi && sudo make";
+      then
+        echo -e "${red}Failed${plain} - Removing damaged targets"
+        rm ../../Java/Personal/hid4java/src/main/resources/linux-armel/libhidapi.so
+        rm ../../Java/Personal/hid4java/src/main/resources/linux-armel/libhidapi-libusb.so
+      else
+        echo -e "${green}OK${plain}"
+        cp linux/.libs/libhidapi-hidraw.so ../../Java/Personal/hid4java/src/main/resources/linux-armel/libhidapi.so
+        cp libusb/.libs/libhidapi-libusb.so ../../Java/Personal/hid4java/src/main/resources/linux-armel/libhidapi-libusb.so
+    fi
+  else
+    echo -e "${yellow}Skipping linux-armel${plain}"
 fi
 echo -e "${green}------------------------------------------------------------------------${plain}"
 


### PR DESCRIPTION
* Switched from armv6 to armv5 compiler
* Removes the Debian compiler and uses the dockcross-provided compiler instead
* Shims `PKG_CONFIG_PATH` and `/usr/include/libudev.h` with a strategy similar to #142 
* Disables building `hidtest` with a strategy similar to #142 

Closes #119