### PR TITLE
Add hidListenerException() callback to HidServicesListener

### DIFF
--- a/src/main/java/org/hid4java/HidServicesListener.java
+++ b/src/main/java/org/hid4java/HidServicesListener.java
@@ -66,4 +66,18 @@ public interface HidServicesListener extends EventListener {
    */
   void hidDataReceived(HidServicesEvent event);
 
+  /**
+   * An uncaught exception was thrown
+   * <p>
+   * <b>Note:</b> Any exceptions that occur in this callback will
+   * be silently ignored.
+   *
+   * @param event The event
+   * @param cause The uncaught exception
+   */
+  @SuppressWarnings({"unused", "CallToPrintStackTrace"})
+  default void hidListenerException(HidServicesEvent event, Throwable cause) {
+      /* TODO: more robust logging */
+      cause.printStackTrace();
+  }
 }

--- a/src/main/java/org/hid4java/event/HidServicesListenerList.java
+++ b/src/main/java/org/hid4java/event/HidServicesListenerList.java
@@ -115,12 +115,15 @@ public class HidServicesListenerList {
           HidServicesEvent event = new HidServicesEvent(hidDevice);
 
           for (final HidServicesListener listener : toArray()) {
-            listener.hidDeviceAttached(event);
+            try {
+              listener.hidDeviceAttached(event);
+            } catch(Throwable cause) {
+              listener.hidListenerException(event, cause);
+            }
           }
 
         }
       });
-
   }
 
   /**
@@ -139,7 +142,11 @@ public class HidServicesListenerList {
           HidServicesEvent event = new HidServicesEvent(hidDevice);
 
           for (final HidServicesListener listener : toArray()) {
-            listener.hidDeviceDetached(event);
+            try {
+              listener.hidDeviceDetached(event);
+            } catch(Throwable cause) {
+              listener.hidListenerException(event, cause);
+            }
           }
 
         }
@@ -163,7 +170,11 @@ public class HidServicesListenerList {
           HidServicesEvent event = new HidServicesEvent(hidDevice);
 
           for (final HidServicesListener listener : toArray()) {
-            listener.hidFailure(event);
+            try {
+              listener.hidFailure(event);
+            } catch(Throwable cause) {
+              listener.hidListenerException(event, cause);
+            }
           }
 
         }
@@ -188,7 +199,11 @@ public class HidServicesListenerList {
           HidServicesEvent event = new HidServicesEvent(hidDevice, dataReceived);
 
           for (final HidServicesListener listener : toArray()) {
-            listener.hidDataReceived(event);
+            try {
+              listener.hidDataReceived(event);
+            } catch(Throwable cause) {
+              listener.hidListenerException(event, cause);
+            }
           }
 
         }


### PR DESCRIPTION
I thought this might come in handy. The first time I was having exceptions occur, I spent a good while trying to figure out why my application was simply doing nothing (no stack traces, no crashes, nothing). This change also allows other callbacks to be called even when the previous one fails. Currently, if we have a list of listeners A, B, and C and B throws an exception, only A and B will have been called and C will never be called.